### PR TITLE
perf: implement more `DrawTarget` methods to improve performance

### DIFF
--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -1,0 +1,228 @@
+//! # Example: Analog Clock
+//!
+//! This example shows some more advanced usage of Embedded Graphics. It draws a round clock face
+//! with hour, minute and second hands. A digital clock is drawn in the middle of the clock. The
+//! whole thing is updated with your computer's local time every 50ms.
+//!
+//! This example is based on the `embedded-graphics` example `clock.rs`.
+
+#![no_std]
+#![no_main]
+
+use alloc::format;
+use vexide::{
+    devices::display::{RenderMode, TouchState},
+    prelude::*,
+    time::Instant,
+};
+use vexide_embedded_graphics::DisplayDriver;
+
+use core::f32::consts::PI;
+use embedded_graphics::{
+    mono_font::{ascii::FONT_9X15, MonoTextStyle},
+    pixelcolor::Rgb888,
+    prelude::*,
+    primitives::{Circle, Line, PrimitiveStyle, PrimitiveStyleBuilder, Rectangle},
+    text::Text,
+};
+
+extern crate alloc;
+
+/// The margin between the clock face and the display border.
+const MARGIN: u32 = 10;
+
+/// Converts a polar coordinate (angle/distance) into an (X, Y) coordinate centered around the
+/// center of the circle.
+///
+/// The angle is relative to the 12 o'clock position and the radius is relative to the edge of the
+/// clock face.
+fn polar(circle: &Circle, angle: f32, radius_delta: i32) -> Point {
+    let radius = circle.diameter as f32 / 2.0 + radius_delta as f32;
+
+    circle.center()
+        + Point::new(
+            (angle.sin() * radius) as i32,
+            -(angle.cos() * radius) as i32,
+        )
+}
+
+/// Converts an hour into an angle in radians.
+fn hour_to_angle(hour: u32) -> f32 {
+    // Convert from 24 to 12 hour time.
+    let hour = hour % 12;
+
+    (hour as f32 / 12.0) * 2.0 * PI
+}
+
+/// Converts a sexagesimal (base 60) value into an angle in radians.
+fn sexagesimal_to_angle(value: u32) -> f32 {
+    (value as f32 / 60.0) * 2.0 * PI
+}
+
+/// Creates a centered circle for the clock face.
+fn create_face(target: &impl DrawTarget) -> Circle {
+    // The draw target bounding box can be used to determine the size of the display.
+    let bounding_box = target.bounding_box();
+
+    let diameter = bounding_box.size.width.min(bounding_box.size.height) - 2 * MARGIN;
+
+    Circle::with_center(bounding_box.center(), diameter)
+}
+
+/// Draws a circle and 12 graduations as a simple clock face.
+fn draw_face<D>(target: &mut D, clock_face: &Circle) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb888>,
+{
+    // Draw the outer face.
+    (*clock_face)
+        .into_styled(PrimitiveStyle::with_stroke(Rgb888::CSS_BLUE, 2))
+        .draw(target)?;
+
+    // Draw 12 graduations.
+    for angle in (0..12).map(hour_to_angle) {
+        // Start point on circumference.
+        let start = polar(clock_face, angle, 0);
+
+        // End point offset by 10 pixels from the edge.
+        let end = polar(clock_face, angle, -10);
+
+        Line::new(start, end)
+            .into_styled(PrimitiveStyle::with_stroke(Rgb888::CSS_AZURE, 1))
+            .draw(target)?;
+    }
+
+    Ok(())
+}
+
+/// Draws a clock hand.
+fn draw_hand<D>(
+    target: &mut D,
+    clock_face: &Circle,
+    angle: f32,
+    length_delta: i32,
+) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb888>,
+{
+    let end = polar(clock_face, angle, length_delta);
+
+    Line::new(clock_face.center(), end)
+        .into_styled(PrimitiveStyle::with_stroke(Rgb888::CSS_RED, 1))
+        .draw(target)
+}
+
+/// Draws a decorative circle on the second hand.
+fn draw_second_decoration<D>(
+    target: &mut D,
+    clock_face: &Circle,
+    angle: f32,
+    length_delta: i32,
+) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb888>,
+{
+    let decoration_position = polar(clock_face, angle, length_delta);
+
+    let decoration_style = PrimitiveStyleBuilder::new()
+        .fill_color(Rgb888::CSS_YELLOW)
+        .stroke_color(Rgb888::CSS_RED)
+        .stroke_width(1)
+        .build();
+
+    // Draw a fancy circle near the end of the second hand.
+    Circle::with_center(decoration_position, 11)
+        .into_styled(decoration_style)
+        .draw(target)
+}
+
+/// Draw digital clock just above center with black text on a white background
+fn draw_digital_clock<D>(
+    target: &mut D,
+    clock_face: &Circle,
+    time_str: &str,
+) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb888>,
+{
+    // Create a styled text object for the time text.
+    let mut text = Text::new(
+        time_str,
+        Point::zero(),
+        MonoTextStyle::new(&FONT_9X15, Rgb888::CSS_BLACK),
+    );
+
+    // Move text to be centered between the 12 o'clock point and the center of the clock face.
+    text.translate_mut(
+        clock_face.center()
+            - text.bounding_box().center()
+            - clock_face.bounding_box().size.y_axis() / 4,
+    );
+
+    // Add a background around the time digits.
+    // Note that there is no bottom-right padding as this is added by the font renderer itself.
+    let text_dimensions = text.bounding_box();
+    Rectangle::new(
+        text_dimensions.top_left - Point::new(3, 3),
+        text_dimensions.size + Size::new(4, 4),
+    )
+    .into_styled(PrimitiveStyle::with_fill(Rgb888::CSS_WHITE))
+    .draw(target)?;
+
+    // Draw the text after the background is drawn.
+    text.draw(target)?;
+
+    Ok(())
+}
+
+#[vexide::main]
+async fn main(peripherals: Peripherals) -> Result<(), core::convert::Infallible> {
+    let mut display = DisplayDriver::new(peripherals.display);
+    display.set_render_mode(RenderMode::DoubleBuffered);
+
+    let clock_face = create_face(&display);
+
+    let start = Instant::now();
+    'running: loop {
+        let time = start.elapsed();
+
+        // Calculate the position of the three clock hands in radians.
+        let hours_radians = hour_to_angle(time.as_secs() as u32 / 3600 % 12);
+        let minutes_radians = sexagesimal_to_angle((time.as_secs() as u32 % 3600) / 60);
+        let seconds_radians = sexagesimal_to_angle(time.as_secs() as u32 % 60);
+
+        let digital_clock_text = format!(
+            "{:02}:{:02}:{:02}.{:03}",
+            time.as_secs() / 3600 % 12,
+            (time.as_secs() % 3600) / 60,
+            time.as_secs() % 60,
+            time.as_millis() % 1000
+        );
+
+        display.clear(Rgb888::CSS_LIGHT_CORAL)?;
+
+        draw_face(&mut display, &clock_face)?;
+        draw_hand(&mut display, &clock_face, hours_radians, -60)?;
+        draw_hand(&mut display, &clock_face, minutes_radians, -30)?;
+        draw_hand(&mut display, &clock_face, seconds_radians, 0)?;
+        draw_second_decoration(&mut display, &clock_face, seconds_radians, -20)?;
+
+        // Draw digital clock just above center.
+        draw_digital_clock(&mut display, &clock_face, &digital_clock_text)?;
+
+        // Draw a small circle over the hands in the center of the clock face.
+        // This has to happen after the hands are drawn so they're covered up.
+        Circle::with_center(clock_face.center(), 9)
+            .into_styled(PrimitiveStyle::with_fill(Rgb888::CSS_RED))
+            .draw(&mut display)?;
+
+        if matches!(display.touch_status().state, TouchState::Pressed) {
+            // If the screen is touched, exit the loop.
+            break 'running Ok(());
+        }
+
+        display.render();
+
+        sleep(core::time::Duration::from_millis(50)).await;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ impl DrawTarget for DisplayDriver {
     }
 
     // Note: clear is not implemented because vexDisplayErase does not allow
-    // the change of the background color.
+    // changing the background color.
 
     fn fill_contiguous<I>(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,22 @@ impl DisplayDriver {
     pub fn touch_status(&self) -> TouchEvent {
         self.display.touch_status()
     }
+
+    /// Sets the rendering mode of the display
+    pub fn set_render_mode(&mut self, mode: RenderMode) {
+        self.display.set_render_mode(mode);
+    }
+
+    /// Returns the current rendering mode of the display
+    #[must_use]
+    pub fn render_mode(&self) -> RenderMode {
+        self.display.render_mode()
+    }
+
+    /// Renders the display if the rendering mode is set to [`RenderMode::DoubleBuffered`].
+    pub fn render(&mut self) {
+        self.display.render();
+    }
 }
 
 impl OriginDimensions for DisplayDriver {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,10 @@ impl DrawTarget for DisplayDriver {
             {
                 unsafe {
                     vex_sdk::vexDisplayForegroundColor(color.into_storage());
-                    vex_sdk::vexDisplayPixelSet(pos.x as u32, pos.y as u32 + 0x20);
+                    vex_sdk::vexDisplayPixelSet(
+                        pos.x as u32,
+                        Display::HEADER_HEIGHT as u32 + pos.y as u32,
+                    );
                 }
             }
         });
@@ -161,9 +164,9 @@ impl DrawTarget for DisplayDriver {
             unsafe {
                 vexDisplayCopyRect(
                     area.top_left.x,
-                    0x20 + area.top_left.y,
+                    Display::HEADER_HEIGHT as i32 + area.top_left.y,
                     bottom_right.x,
-                    0x20 + bottom_right.y,
+                    Display::HEADER_HEIGHT as i32 + bottom_right.y,
                     self.buffer.as_mut_ptr(),
                     area.size.width as i32,
                 );
@@ -183,9 +186,9 @@ impl DrawTarget for DisplayDriver {
                 vexDisplayForegroundColor(color.into_storage());
                 vexDisplayRectFill(
                     area.top_left.x,
-                    0x20 + area.top_left.y,
+                    Display::HEADER_HEIGHT as i32 + area.top_left.y,
                     bottom_right.x,
-                    bottom_right.y + 0x20,
+                    Display::HEADER_HEIGHT as i32 + bottom_right.y,
                 );
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,44 +1,44 @@
 //! [`embedded-graphics`] Driver for the VEX V5
-//! 
+//!
 //! [`embedded-graphics`]: https://crates.io/crates/embedded-graphics
-//! 
+//!
 //! This crate provides a [`DrawTarget`] implementation for the VEX V5 brain display,
 //! allowing you to draw to the display using the `embedded-graphics` ecosystem.
-//! 
+//!
 //! # Usage
-//! 
+//!
 //! To begin, turn your `display` peripheral into a [`DisplayDriver`]:
-//! 
+//!
 //! ```
 //! #![no_std]
 //! #![no_main]
-//! 
+//!
 //! use vexide::prelude::*;
 //! use vexide_embedded_graphics::DisplayDriver;
-//! 
+//!
 //! #[vexide::main]
 //! async fn main(peripherals: Peripherals) {
 //!     let mut display = DisplayDriver::new(peripherals.display);
 //! }
 //! ```
-//! 
+//!
 //! [`DisplayDriver`] is a [`DrawTarget`] that the `embedded-graphics` crate is
 //! able to draw to.
-//! 
+//!
 //! ```
 //! #![no_std]
 //! #![no_main]
-//! 
+//!
 //! use vexide::prelude::*;
 //! use vexide_embedded_graphics::DisplayDriver;
-//! 
+//!
 //! use embedded_graphics::{
 //!     mono_font::{ascii::FONT_6X10, MonoTextStyle},
 //!     pixelcolor::Rgb888,
 //!     prelude::*,
 //!     text::Text,
 //! };
-//! 
+//!
 //! #[vexide::main]
 //! async fn main(peripherals: Peripherals) {
 //!     let mut display = DisplayDriver::new(peripherals.display);
@@ -49,9 +49,9 @@
 //!         .unwrap();
 //! }
 //! ```
-//! 
+//!
 //! Check out the [`embedded-graphics` docs] for more examples.
-//! 
+//!
 //! [`embedded-graphics` docs]: https://docs.rs/embedded-graphics/latest/embedded_graphics/examples/index.html
 
 #![no_std]
@@ -77,10 +77,15 @@ pub struct DisplayDriver {
 
 impl DisplayDriver {
     /// Create a new [`DisplayDriver`] from a [`Display`].
-    /// 
+    ///
     /// The display peripheral must be moved into this struct,
     /// as it is used to render the display and having multiple
     /// mutable references to it is unsafe.
+    ///
+    /// It is recommended to use a frame buffer like [`embedded_graphics_framebuf`]
+    /// in order to reduce flickering.
+    ///
+    /// [`embedded_graphics_framebuf`]: https://crates.io/crates/embedded-graphics-framebuf
     #[must_use]
     pub fn new(mut display: Display) -> Self {
         display.set_render_mode(vexide::devices::display::RenderMode::DoubleBuffered);
@@ -131,7 +136,7 @@ impl DrawTarget for DisplayDriver {
                 0,
                 0x20,
                 Display::HORIZONTAL_RESOLUTION.into(),
-                Display::VERTICAL_RESOLUTION.into(),
+                0x20 + i32::from(Display::VERTICAL_RESOLUTION),
                 self.triple_buffer.as_mut_ptr(),
                 Display::HORIZONTAL_RESOLUTION.into(),
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,14 +58,14 @@
 
 use core::convert::Infallible;
 use embedded_graphics_core::{pixelcolor::Rgb888, prelude::*};
-use vexide::devices::display::{Display, TouchEvent};
+use vex_sdk::{vexDisplayCopyRect, vexDisplayForegroundColor, vexDisplayRectFill};
+use vexide::devices::display::{Display, RenderMode, TouchEvent};
 
 /// An embedded-graphics draw target for the V5 Brain display
 /// Currently, this does not support touch detection like the regular [`Display`] API.
 pub struct DisplayDriver {
     display: Display,
-    triple_buffer:
-        [u32; Display::HORIZONTAL_RESOLUTION as usize * Display::VERTICAL_RESOLUTION as usize],
+    buffer: [u32; Display::HORIZONTAL_RESOLUTION as usize * Display::VERTICAL_RESOLUTION as usize],
 }
 
 impl DisplayDriver {
@@ -74,18 +74,12 @@ impl DisplayDriver {
     /// The display peripheral must be moved into this struct,
     /// as it is used to render the display and having multiple
     /// mutable references to it is unsafe.
-    ///
-    /// It is recommended to use a frame buffer like [`embedded_graphics_framebuf`]
-    /// in order to reduce flickering.
-    ///
-    /// [`embedded_graphics_framebuf`]: https://crates.io/crates/embedded-graphics-framebuf
     #[must_use]
-    pub fn new(mut display: Display) -> Self {
-        display.set_render_mode(vexide::devices::display::RenderMode::DoubleBuffered);
+    pub fn new(display: Display) -> Self {
         Self {
             display,
             #[allow(clippy::large_stack_arrays)] // we got plenty
-            triple_buffer: [0; Display::HORIZONTAL_RESOLUTION as usize
+            buffer: [0; Display::HORIZONTAL_RESOLUTION as usize
                 * Display::VERTICAL_RESOLUTION as usize],
         }
     }
@@ -115,26 +109,70 @@ impl DrawTarget for DisplayDriver {
     where
         I: IntoIterator<Item = Pixel<Self::Color>>,
     {
-        pixels
-            .into_iter()
-            .map(|p| (p.0, p.1.into_storage()))
-            .for_each(|(pos, col)| {
-                self.triple_buffer
-                    [pos.y as usize * Display::HORIZONTAL_RESOLUTION as usize + pos.x as usize] =
-                    col;
-            });
+        pixels.into_iter().for_each(|Pixel(pos, color)| {
+            if pos.x >= 0
+                && pos.x < Display::HORIZONTAL_RESOLUTION as i32
+                && pos.y >= 0
+                && pos.y < Display::VERTICAL_RESOLUTION as i32
+            {
+                unsafe {
+                    vex_sdk::vexDisplayForegroundColor(color.into_storage());
+                    vex_sdk::vexDisplayPixelSet(pos.x as u32, pos.y as u32 + 0x20);
+                }
+            }
+        });
 
-        unsafe {
-            vex_sdk::vexDisplayCopyRect(
-                0,
-                0x20,
-                Display::HORIZONTAL_RESOLUTION.into(),
-                0x20 + i32::from(Display::VERTICAL_RESOLUTION),
-                self.triple_buffer.as_mut_ptr(),
-                Display::HORIZONTAL_RESOLUTION.into(),
-            );
-        };
-        self.display.render();
+        Ok(())
+    }
+
+    // Note: clear is not implemented because vexDisplayErase does not allow
+    // the change of the background color.
+
+    fn fill_contiguous<I>(
+        &mut self,
+        area: &embedded_graphics_core::primitives::Rectangle,
+        colors: I,
+    ) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Self::Color>,
+    {
+        if let Some(bottom_right) = area.bottom_right() {
+            // Copy the colors into the buffer
+            colors.into_iter().enumerate().for_each(|(i, color)| {
+                self.buffer[i] = color.into_storage();
+            });
+            // Copy the buffer to the display
+            unsafe {
+                vexDisplayCopyRect(
+                    area.top_left.x,
+                    0x20 + area.top_left.y,
+                    bottom_right.x,
+                    0x20 + bottom_right.y,
+                    self.buffer.as_mut_ptr(),
+                    area.size.width as i32,
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn fill_solid(
+        &mut self,
+        area: &embedded_graphics_core::primitives::Rectangle,
+        color: Self::Color,
+    ) -> Result<(), Self::Error> {
+        if let Some(bottom_right) = area.bottom_right() {
+            unsafe {
+                vexDisplayForegroundColor(color.into_storage());
+                vexDisplayRectFill(
+                    area.top_left.x,
+                    0x20 + area.top_left.y,
+                    bottom_right.x,
+                    bottom_right.y + 0x20,
+                );
+            }
+        }
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,14 +58,7 @@
 
 use core::convert::Infallible;
 use embedded_graphics_core::{pixelcolor::Rgb888, prelude::*};
-use vexide::devices::{
-    display::{Display, TouchEvent},
-    rgb::Rgb,
-};
-
-fn rgb_into_raw(rgb: Rgb<u8>) -> u32 {
-    (u32::from(rgb.r) << 16) + (u32::from(rgb.g) << 8) + u32::from(rgb.b)
-}
+use vexide::devices::display::{Display, TouchEvent};
 
 /// An embedded-graphics draw target for the V5 Brain display
 /// Currently, this does not support touch detection like the regular [`Display`] API.
@@ -124,7 +117,7 @@ impl DrawTarget for DisplayDriver {
     {
         pixels
             .into_iter()
-            .map(|p| (p.0, rgb_into_raw(Rgb::new(p.1.r(), p.1.g(), p.1.b()))))
+            .map(|p| (p.0, p.1.into_storage()))
             .for_each(|(pos, col)| {
                 self.triple_buffer
                     [pos.y as usize * Display::HORIZONTAL_RESOLUTION as usize + pos.x as usize] =


### PR DESCRIPTION
There's a couple of changes going on here:

1. I updated `vexDisplayCopyRect` invocations to properly add `0x20` for the header bar to `y2` as well as `y1`.

2. I modified `<DisplayDriver as DrawTarget>::draw_iter` to fill individual pixels. I think that was the intention of `embedded-graphics` and it vastly improves performance.

3. I implemented `fill_contiguous` which is intended to be used for copying images and such to use `vexDisplayCopyRect`. I re-used the slice in `DisplayDriver` to save allocations all the time, but it might be better to just dynamically allocate instead of allocating a buffer of the max size up front.

4. I implemented `fill_solid` to fill rectanges the usual way.

5. I added methods to update the rendering mode of the display.

Essentially, the original implementation just copied the entire buffer over at once, which wasn't very good for performance since `embedded-graphics` calls `draw_iter` several times per frame typically, making for slow frame rates on complex scenes.